### PR TITLE
Beheer: test nieuwe publicatie van GitHub pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,5 @@ jobs:
   publish:
     needs: build
     name: Publish (Logius)
-    uses: Logius-standaarden/Automatisering/.github/workflows/publish.yml@main
+    uses: Logius-standaarden/Automatisering/.github/workflows/publish.yml@pr-timvdlippe-fix-publiceren-naar-github-pages
     secrets: inherit


### PR DESCRIPTION
Hiermee kunnen we de publicatie testen voordat het op andere standaarden al wordt toegepast.